### PR TITLE
Make hotp-verification hashes same across two CIs (WIP)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,11 @@ jobs:
           path: build/qemu-coreboot/hashes.txt
 
       - run:
+          name: clear old cache for libremkey-hotp-verification*
+          command: |
+            rm -rf build/libremkey-hotp-verification* -v
+
+      - run:
           name: x230-hotp_verification
           command: |
             make --load 2 \
@@ -77,6 +82,10 @@ jobs:
           name: Archiving build logs to bundle in artifacts
           command: |
             tar zcvf logs.tar.gz ./build/log/*
+      - run:
+          name: Archiving hotp verification build files
+          command: |
+            tar zcvf libremkey-hotp.tar.gz ./build/libremkey-hotp-verification*
 
 
       - store-artifacts:
@@ -89,6 +98,8 @@ jobs:
           path: build/x230-hotp_verification/initrd.cpio.xz
       - store-artifacts:
           path: logs.tar.gz
+      - store-artifacts:
+          path: libremkey-hotp.tar.gz
 
       - save_cache:
           key: heads-{{ .Branch }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,8 @@ image: fedora:30
 
 variables:
   DOCKER_DRIVER: overlay2
+  V: "1"
+  CACHE_VERSION: "1"
 
 stages:
   - build
@@ -11,16 +13,23 @@ build:
   retry: 2
   cache:
     paths:
-      - ./
-    key: "$CI_COMMIT_REF_SLUG"
+      - packages
+      - crossgcc
+      - build
+    key: "$CI_COMMIT_REF_SLUG-$CACHE_VERSION"
   script:
     - dnf install -y @development-tools gcc-c++ gcc-gnat zlib-devel perl-Digest-MD5 perl-Digest-SHA uuid-devel pcsc-tools ncurses-devel lbzip2 libuuid-devel lzma elfutils-libelf-devel bc bzip2 bison flex git gnupg iasl m4 nasm patch python wget libusb-devel cmake automake pv bsdiff autoconf libtool expat-devel boost-devel libaio-devel cpio texinfo diceware
-    - git fetch origin 
+# below should not be needed anymore once the cache paths are corrected # TODO remove
+#    - git clone https://gitlab.com/szszszsz/heads.git && rm .git -rf && mv heads/.git . && rm heads -rf
+    - git fetch origin
     - git reset --hard origin/$CI_COMMIT_REF_NAME
+    - rm -rf build/libremkey-hotp-verification* -v
     - make BOARD=x230-hotp_verification || (find ./build/log/ -cmin 1|xargs tail; exit 1)
     - echo "x230-hotp_verification hashes:"
     - cat ./build/x230-hotp_verification/hashes.txt
     - tar zcvf logs.tar.gz ./build/log/*
+    - tar zcvf libremkey-hotp.tar.gz ./build/libremkey-hotp-verification*
+
   artifacts:
     paths:
       - ./build/x230-hotp_verification/coreboot.rom
@@ -29,3 +38,4 @@ build:
       - ./build/x230-hotp_verification/hashes.txt
       - ./build/x230-hotp_verification/initrd.cpio.xz
       - ./logs.tar.gz
+      - ./libremkey-hotp.tar.gz

--- a/modules/libremkey-hotp-verification
+++ b/modules/libremkey-hotp-verification
@@ -2,11 +2,11 @@ modules-$(CONFIG_LIBREMKEY) += libremkey-hotp-verification
 
 libremkey-hotp-verification_depends := libusb $(musl_dep)
 
-libremkey-hotp-verification_version := d4948fddd617022635129f9b00db3f98de01016f
+libremkey-hotp-verification_version := 809953b9b4bef97a4cffaa20d675bd7fe9d8da53
 libremkey-hotp-verification_dir := libremkey-hotp-verification-$(libremkey-hotp-verification_version)
 libremkey-hotp-verification_tar := nitrokey-hotp-verification-$(libremkey-hotp-verification_version).tar.gz
 libremkey-hotp-verification_url := https://github.com/Nitrokey/nitrokey-hotp-verification/archive/$(libremkey-hotp-verification_version).tar.gz
-libremkey-hotp-verification_hash := 36125fc7986afdfc309e963f767fe8f10de109da022d222b0bd9ac26bf18eb52
+libremkey-hotp-verification_hash := 251e5cef74e4e45eeddc49e4a1da1e22d1de774cd32cb0451a9030579ae958ba
 
 libremkey-hotp-verification_target := \
 	$(MAKE_JOBS) \
@@ -16,10 +16,12 @@ libremkey-hotp-verification_output := \
 	libremkey_hotp_verification \
 	libremkey_hotp_initialize
 
+FLAGS=-fdebug-prefix-map=$PWD=heads -gno-record-gcc-switches -DNDEBUG -fno-guess-branch-probability -Wdate-time -frandom-seed=0x42 -O0
+
 libremkey-hotp-verification_configure := \
   INSTALL="$(INSTALL)" \
   CROSS="$(CROSS)" \
-  cmake -DADD_GIT_INFO=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=./Toolchain-heads.cmake -DCMAKE_AR="$(CROSS)ar" . 
+  $(CROSS_TOOLS) $(MAKE) LDFLAGS="$(INSTALL)/lib/libusb-1.0.so" && $(MAKE) install INSTALL="$(INSTALL)"
 
 libremkey-hotp-verification_depends  += hidapi
 modules-y += hidapi


### PR DESCRIPTION
Move from CMake to GNU Make
Correct Gitlab cache
Change hotp-verification version to one supporting Makefile build
Add flags making build reproducible

Debug (to remove):
Store hotp-verification as artifact for debug purposes (to remove)
Clear hotp-verification's cache-restored build

