### PR TITLE
Test: strip debug at binaries install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -407,7 +407,7 @@ endef
 define initrd_bin_add =
 $(initrd_bin_dir)/$(notdir $1): $1
 	$(call do,INSTALL-BIN,$$(<:$(pwd)/%=%),cp -a "$$<" "$$@")
-	@$(CROSS)strip --preserve-dates "$$@" 2>&-; true
+	@$(CROSS)strip --preserve-dates --strip-debug "$$@" 2>&-; true
 initrd_bins += $(initrd_bin_dir)/$(notdir $1)
 endef
 


### PR DESCRIPTION
Just a test. Linux modules were stripped of debugat install.
Wanted to know if same could be done at module install to save additional space.