### PR TITLE
add more volunteers as board testers for the T480

### DIFF
--- a/BOARD_TESTERS.md
+++ b/BOARD_TESTERS.md
@@ -34,8 +34,7 @@ xx4x(Haswell):
 
 xx8x(Kaby Lake Refresh):
 ===
-- [ ] t480: @gaspar-ilom
-- [ ] t480s (similar to t480): TODO: NOT SUPPORTED OR TESTED YET
+- [ ] t480: @gaspar-ilom @doritos4mlady @MattClifton76
 
 Librems:
 ===


### PR DESCRIPTION
remove the not (yet) supported t480s from the board testers file

https://github.com/linuxboot/heads/pull/1906