### PR TITLE
refactor printing of battery state to confuse less users

### DIFF
--- a/initrd/bin/oem-system-info-xx30
+++ b/initrd/bin/oem-system-info-xx30
@@ -12,13 +12,7 @@ export BG_COLOR_MAIN_MENU="normal"
 
 TRACE_FUNC
 
-battery_status=""
-for battery in /sys/class/power_supply/BAT*; do
-	if [[ -d "${battery}" ]]; then
-		battery_status+="$(awk '{printf "\\nBattery %s charge: %s%%\\nBattery %s health: %s%%", substr($1,4), $2, substr($1,4), $3}' <<< "$(print_battery_state "${battery}")")"
-	fi
-done
-battery_status="${battery_status:+${battery_status}\n}"
+battery_status="$(print_battery_state)"
 
 usb="$(lsusb)"
 pci="$(lspci)"

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -1217,13 +1217,42 @@ fromhex_plain() {
 	fold -w 60 | xxd -p -r
 }
 
-print_battery_state() {
-  TRACE_FUNC
+print_battery_charge() {
+	local battery
 	battery="$1"
-	DEBUG "Battery: $1"
-	battery_charge=$(awk "BEGIN {printf \"%d\", ($(cat "${battery}/charge_now")/$(cat "${battery}/charge_full")*100)}")
-	battery_health=$(awk "BEGIN {printf \"%d\", ($(cat "${battery}/charge_full")/$(cat "${battery}/charge_full_design")*100)}")
-	echo "$(basename "${battery}") ${battery_charge} ${battery_health}"
+	echo "$((100*$(cat "${battery}/charge_now")/$(cat "${battery}/charge_full")))"
+}
+
+print_battery_health() {
+	local battery
+	battery="$1"
+	echo "$((100*$(cat "${battery}/charge_full")/$(cat "${battery}/charge_full_design")))"
+}
+
+print_battery_name() {
+	local battery
+	battery="$1"
+	echo "$(cat "${battery}/manufacturer") $(cat "${battery}/model_name")"
+}
+
+# Print the charging and health state for all batteries
+# Print the maufacturer and model name for each battery if more than 1
+# The printed string contains the full formatting including leading an trailing "\n" strings
+print_battery_state() {
+	local battery_status
+	battery_status=""
+	all_batteries=(/sys/class/power_supply/BAT*)
+	for battery in "${all_batteries[@]}"; do
+		if [[ -d "${battery}" ]]; then
+			battery_name="Battery"
+			if [ "${#all_batteries[@]}" -gt 1 ]; then
+				battery_name+=" $(print_battery_name "${battery}")"
+			fi
+			battery_status+="\n${battery_name} charge: $(print_battery_charge "${battery}")%"
+			battery_status+="\n${battery_name} health: $(print_battery_health "${battery}")%"
+		fi
+	done
+	echo "${battery_status:+${battery_status}\n}"
 }
 
 generate_random_mac_address() {

--- a/initrd/etc/gui_functions
+++ b/initrd/etc/gui_functions
@@ -165,13 +165,7 @@ file_selector() {
 
 show_system_info() {
 	TRACE_FUNC
-	battery_status=""
-	for battery in /sys/class/power_supply/BAT*; do
-		if [[ -d "${battery}" ]]; then
-			battery_status+="$(awk '{printf "\\nBattery %s charge: %s%%\\nBattery %s health: %s%%", substr($1,4), $2, substr($1,4), $3}' <<< "$(print_battery_state "${battery}")")"
-		fi
-	done
-	battery_status="${battery_status:+${battery_status}\n}"
+	battery_status="$(print_battery_state)"
 
 	memtotal=$(cat /proc/meminfo | grep 'MemTotal' | tr -s ' ' | cut -f2 -d ' ')
 	memtotal=$((${memtotal} / 1024 / 1024 + 1))


### PR DESCRIPTION
Fixes the changes requested by @JonathonHall-Purism https://github.com/linuxboot/heads/pull/1906#pullrequestreview-2641938107

print manufacturer and model name in case there are multiple batteries for each of them instead of arbitrary "BAT*" string

https://github.com/linuxboot/heads/pull/1906